### PR TITLE
add versions to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests
-pyyaml
-click
-pymisp
+requests>=2.12.0
+pyyaml>=3.12
+click>=6.6
+pymisp>=2.4.68


### PR DESCRIPTION
This PR adds some basic minimum version  requirements to pip's `requirements.txt`.