### PR TITLE
extend tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,16 @@ python:
   - "3.6-dev" # 3.6 development branch
   - "3.7-dev" # 3.7 development branch
   - "nightly" # currently points to 3.7-dev
-# command to install dependencies
+# install dependencies
 install: "pip3 install -r requirements.txt"
-# command to run tests
-script: ./tie2misp --help
+addons:
+  apt:
+    packages:
+    - jq
+# prepare and run tests
+script:
+  - testdata/test_run.sh
+# TIE token (encrypted)
+env:
+  global:
+    secure: "ARJp6FYRRock0kTojFfFOAi/8R0M+kqQnrkWJ6/7gwlWX296BjMUdHFUD+Ds/H7V/kQbpdQ5oNAZZa8C7kmirFQW1yjiUZagkTW0rlgCzqZDyc9Bh2KbBZgZpZMc37oApRMuVM2zTlqOgf5+QOI4p1uaQqxni7R50YqERW2nvQGYjaHVNhTYZ9xzCm29aSqtOlRlZxefhS5Xw840imz+bMOAF1CvJh4o/9s+0tnKxI3U5bpDplyvRTzxK0sTV4br9jdOKS3wNMGxJVjBVwwQqK9ZW8jpg85D2SDqm2Mf90SH/iN3vHkGNoQZ9ogYqatpZEqjlNLPb7UkJaf91Dw9YJ/ebdmbE/6JfVRziwh97J3X/piFRADj8OeQmqYqR9XPgr3OJlB1HwvDRBsi8KVMoklvRacgHI+J3I+NRf032TUnyYwWEeILYOeS8AQzxW1M10+Ivmf60+pP0CLCcrDSEF8Vx0XgpNg2WypauVZks2MoRoqpsxR6L+CkQDwH5DZOQX+0akDpODYwipbAcBOhpvqJZU3Idvh0JCKDesyrp/xTnKGN2lCAAqpPvpEWsfFX+ogp5dRXZSfFSMp01ngJDQLZ7ktgPrVjxQS18jXw1b4+nBH1qE927G0Y/q1Nfhd0fi4cuKNI1407Rc5T+WDj466J0XTWQj7UfWI/gyi3Z44="

--- a/testdata/config.yml
+++ b/testdata/config.yml
@@ -1,0 +1,19 @@
+base:
+  tie_apiurl: "https://tie.dcso.de/api/v1/"
+  tie_apikey: "SETME"
+  misp_apiurl: "https://misp.foo.bar"
+  misp_apikey: "asd22asdt9898asdfj120asd9213jas"
+  misp_verifycert: "False"
+
+organisation:
+  name: "ACME"
+  uuid: "5804adw2-12fe-1234-34av-07lk82aw012a"
+
+events:
+  base_threat_level: "3"
+  published: "False"
+  info_c2server: "TIE Daily C2Server"
+  info_malware: "TIE Daily Malware"
+
+attributes:
+  to_ids: "False"

--- a/testdata/test_run.sh
+++ b/testdata/test_run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+
+
+if [ -z ${TIE_TOKEN+x} ]; then
+   # TIE_TOKEN is not set, simply checking whether tool can run
+   ./tie2misp --help
+else
+    sed "s/SETME/$TIE_TOKEN/" testdata/config.yml > settings/config.yml
+    ./tie2misp c2server --date 2017-03-13 --noupload --file | tail -n 1 | xargs jq '.Event.Attribute | length' > length
+    test `cat length` -gt "0"
+    rm -f settings/config.yml
+fi


### PR DESCRIPTION
This PR adds some additional tests to:
 - if the `TIE_TOKEN` environment variable is set (e.g. via encrypted globals in the main repo's Travis tests) then a sample query will be run against the public TIE API with the Travis token and the number of returned attributes is checked, and
 - if the `TIE_TOKEN` environment variable is not set, it will simply be checked whether the main tool can be executed without problems (e.g. in pull requests from forks where the token is never decrypted).

Please do not merge until the tests pass.